### PR TITLE
Making prev and next buttons properly clickable

### DIFF
--- a/lib/bulma_pagination/bulma_renderer.rb
+++ b/lib/bulma_pagination/bulma_renderer.rb
@@ -59,7 +59,8 @@ module BulmaPagination
     def previous_or_next_page(page, text, classname)
       link_options = @options[:link_options] || {}
       if page
-        tag :li, link(text, page, link_options), class: classname
+        link_options[:class] = classname
+        link(text, page, link_options)
       else
         tag :li, tag(:span, text), class: classname, disabled: true
       end

--- a/lib/bulma_pagination/version.rb
+++ b/lib/bulma_pagination/version.rb
@@ -1,3 +1,3 @@
 module BulmaPagination
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
The prev and next buttons were not entirely clickable. You had to click the link text in the middle but could not click anywhere within the button.

The reason is that the prev and next links were implemented as LI tags and not just A tags.

See: https://bulma.io/documentation/components/pagination/